### PR TITLE
feat: Support loongarch64 and cargo clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         rust-toolchain: [nightly]
-        targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat]
+        targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/src/arch/loongarch64.rs
+++ b/src/arch/loongarch64.rs
@@ -1,0 +1,17 @@
+use core::arch::asm;
+
+const IE_MASK: usize = 1 << 2;
+
+#[inline]
+pub fn local_irq_save_and_disable() -> usize {
+    let mut flags: usize = 0;
+    // clear the `IE` bit, and return the old CSR
+    unsafe { asm!("csrxchg {}, {}, 0x0", inout(reg) flags, in(reg) IE_MASK) };
+    flags & IE_MASK
+}
+
+#[inline]
+pub fn local_irq_restore(flags: usize) {
+    // restore the `IE` bit
+    unsafe { asm!("csrxchg {}, {}, 0x0", in(reg) flags, in(reg) IE_MASK) };
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -10,5 +10,8 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
+    } else if #[cfg(target_arch = "loongarch64")] {
+        mod loongarch64;
+        pub use self::loongarch64::*;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
 //! ```
 
 #![no_std]
-#![feature(asm_const)]
 
 mod arch;
 


### PR DESCRIPTION
1. Add LoongArch64 Support
2. remove `#![feature(asm_const)]` because the feature `asm_const` has been stable since 1.82.0