### PR TITLE
feat: Add ARM architecture support with IRQ handling functions

### DIFF
--- a/src/arch/arm.rs
+++ b/src/arch/arm.rs
@@ -1,0 +1,29 @@
+use core::arch::asm;
+
+/// Bit 7: IRQ disable bit in CPSR
+const IRQ_DISABLE_BIT: usize = 1 << 7;
+
+#[inline]
+pub fn local_irq_save_and_disable() -> usize {
+    let flags: usize;
+    unsafe {
+        // Save CPSR and disable IRQs by setting the I bit
+        asm!(
+            "mrs {0}, cpsr",
+            "cpsid i",
+            out(reg) flags,
+            options(nomem, nostack, preserves_flags)
+        );
+    }
+    flags & IRQ_DISABLE_BIT
+}
+
+#[inline]
+pub fn local_irq_restore(flags: usize) {
+    if flags & IRQ_DISABLE_BIT == 0 {
+        // IRQs were enabled before, re-enable them
+        unsafe {
+            asm!("cpsie i", options(nomem, nostack));
+        }
+    }
+}

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -13,5 +13,8 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64;
         pub use self::loongarch64::*;
+    } else if #[cfg(target_arch = "arm")] {
+        mod arm;
+        pub use self::arm::*;
     }
 }


### PR DESCRIPTION
For ARM32, interrupt control is managed through the I bit (bit 7) of the CPSR (Current Program Status Register).
https://arm-software.github.io/CMSIS_5/Core_A/html/group__CMSIS__CPSR.html